### PR TITLE
Use a plain object for props

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ let X18NSpanElement = React.createClass({
       result = X18N.t.apply(null, this.props._args)
     }
 
-    return React.createElement('span', '', result)
+    return React.createElement('span', {}, result)
   }
 })
 


### PR DESCRIPTION
React.createElement() expect props argument to be a plain object.
